### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2019-08-31-wooorm.md
+++ b/invoices/2019-08-31-wooorm.md
@@ -1,0 +1,17 @@
+# Invoice: unified collective
+
+*   **Date**: 2019-08-31
+*   **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+*   **Rate**: $40/hr (non-profit, open source discount)
+
+## Items
+
+| Item               | Description                    | Hours | Total         |
+| ------------------ | ------------------------------ | ----- | ------------- |
+| unified collective | Development and support (July) | *115* | **$4,600.00** |
+
+* * *
+
+*   **Commits**: [192](https://github.com/search?q=author%3Awooorm+committer-date%3A%222019-08-01..2019-09-01%22&type=Commits)
+*   **Issues and PRs**: [17](https://github.com/search?q=author%3Awooorm+created%3A%222019-08-01..2019-09-01%22&type=Issues)
+*   **Reviews**: [19](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-08-01..2019-09-01%22&s=created&type=Issues)


### PR DESCRIPTION
Hi friends!  👋

This month (August 1 to August 31) was my fourth month of full time OSS!  Thanks to all the sponsors and everyone that helps!  ❤️

### Things that happened

##### Netlify

@netlify is now a [🥇 gold sponsor of unified](https://twitter.com/unifiedjs/status/1161344050655617025) 👏

##### Governance

Governance docs are done! These describe in detail [how teams run](https://github.com/unifiedjs/collective/tree/collective-governance#organization-teams), [how decisions are made](https://github.com/unifiedjs/collective/blob/collective-governance/decisions.md), [how people participate](https://github.com/unifiedjs/collective/blob/collective-governance/members.md), [how the code of conduct is enforced](https://github.com/unifiedjs/collective/blob/collective-governance/moderation.md), [how organizations are managed](https://github.com/unifiedjs/collective/blob/collective-governance/organizations.md), and [the permissions members have](https://github.com/unifiedjs/collective/blob/collective-governance/permissions.md).

This may have felt like a lot of bikeshedding and yak shaving because the collective is running fine now, but it’s really important for a “significant” project to have this, one of my takeaways from #reactgate.

##### Other highlights

*   We have [contributors](https://github.com/unifiedjs/rfcs/blob/master/text/0002-contributor-team.md) teams, and our members now have [more/less rights](https://github.com/unifiedjs/github-tools/issues/3), using the new [GitHub triage and maintain](https://github.blog/changelog/2019-05-23-triage-and-maintain-roles-beta/) roles
*   We have fancy new [GitHub Labels](https://github.com/unifiedjs/github-tools/pull/6) across the collective
*   We have our own email addresses: you can contact `security@unifiedjs.com` to raise a security issue, or mail `titus@unifiedjs.com` to reach me
*   Onboarded [`remark-math`](https://github.com/remarkjs/remark-math), which is now part of the collective

### 🕴🏼 Hours / Rate

See unifiedjs/collective#25, but a bit more: $ 4,600.—, or 115 hours at a rate of $40.

This is slightly higher than the last months. The reason for that is that I’m spending a bit more per month than what is coming in (after taxes).
This amount is a value I can withdraw for the next three months (so I can work
September, October, and November).
My plan is to find some more sponsors and/or a freelance gig that I can do for a bit so the collective can save up some more.

### ✅ August

#### 📊 Numbers

*   **Commits**: [192](https://github.com/search?q=author%3Awooorm+committer-date%3A%222019-08-01..2019-09-01%22&type=Commits)
*   **Issues and PRs**: [17](https://github.com/search?q=author%3Awooorm+created%3A%222019-08-01..2019-09-01%22&type=Issues)
*   **Reviews**: [19](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-08-01..2019-09-01%22&s=created&type=Issues)

### 🗓 September

In September I want to:

*   Work on micromark (finally! really excited about this)
*   Work on docs (making the collective more approachable, website?)
*   Find more sponsors
