### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2021-06-01-wooorm.md
+++ b/invoices/2021-06-01-wooorm.md
@@ -1,0 +1,19 @@
+# Invoice: unified collective
+
+*   **Date**: 2021-06-01
+*   **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+
+## Items
+
+| Item               | Description                   | Total         |
+| ------------------ | ----------------------------- | ------------- |
+| unified collective | Development and support (May) | **$4,600.00** |
+
+***
+
+These numbers are since the previous invoice, which was on 2019-10-31.
+
+*   **Commits**:
+    [8324](https://github.com/search?q=author%3Awooorm+committer-date%3A%222019-11-01..2021-06-01%22%5C\&type=Commits)
+*   **Issues and PRs**: [325](https://github.com/search?q=author%3Awooorm+created%3A%222019-11-01..2021-06-01%22%5C\&type=Issues)
+*   **Reviews**: [321](https://github.com/search?q=reviewed-by%3Awooorm+created%3A%222019-11-01..2021-01-01%22\&type=Issues)


### PR DESCRIPTION
Hi folks!  👋

This is my first invoice in a while (since October 2019). The money ran out back then, in OC, and soon afterwards in my own account, so I quite hastily had to figure something out at the end of 2019 to make ends meet. I made a bunch of books, with a pipeline on top of unified, for Holloway, and around Q2 2020 Salesforce reached out to fund my work on micromark, which made it into reality! I worked with Salesforce till end of August 2020, and have used the money I made with them to fund my open source work until now. As the money is running out again, I wanted to tap into OC.

### ✅ Things that happened

#### micromark

micromark is done! And it works well. Including all the extensions, and the integrations with syntax-tree and remark/rehype/unified. This week it swapped places with `markdown-it` as third most popular markdown parser (after `marked` in second place, and `remark-parse` in first). It’s about to hit v3, the first semver-stable release somewhere this week, without much changes. First to add some docs on how to write extension and then hopefully fix a pesky bug or two.

#### ESM and types

I’ve added [types (through JSDoc) and switched to ESM](https://github.com/unifiedjs/unified/issues/121) in about 120 unified projects already. After micromark is updated, it should be quite smooth sailing to reach to the higher-level ecosystems. There are a couple of other small breaking changes bubbling with ESM/types through the ecosystem from the bottom to the top. Browse the [**Use JSDoc to check and generate TypeScript typings** RFC](https://github.com/unifiedjs/rfcs/pull/5) and [**Adopt ES2015+ features in Unified collective** RFC](https://github.com/unifiedjs/rfcs/pull/4).

#### New labels and BB

One of these is a new triage flow, in part based on labels added by humans, and in part through a bot that automatically triages issues/PRs, called [beep boop](https://github.com/unifiedjs/beep-boop-beta).
[Browse the **Use bots for community health** RFC](https://github.com/unifiedjs/rfcs/pull/6)

#### Misc

Some random things that I can remember:

* `react-markdown` is now maintained under remarkjs. It’s a high-level project with lots of users that are often beginners, which often are low-quality (e.g., not having read the readme or searched through issues). Hopefully bb will help there. It has released 2 major releases already to bring it up to speed with modern JS. It should be smooth sailing from here
* rewrote how MDX is parsed in April 2020 (thanks Gatsby) and again in November (to support micromark)
* `xast` (an xml ast) and `esast` (a js ast) are available in syntax-tree. They don’t have too much written on top of them yet, but it’s interesting that the scope of unified broadens. There’s also [`wooorm/dioscuri`](https://github.com/wooorm/dioscuri) for gemini fans
* Went to Sustain (Brussels) in 2020
* New unified website
* Move from Travis to GH actions
* Move from Spectrum to GH discussions
* Funding fields everywhere

### 🕴🏼 Hours / Rate

Previously (such as [GH-39](https://github.com/unifiedjs/collective/pull/39)) I’ve used $40 per hour as a “reduced oss rate”, and changed how much hours I “worked” based on how much I needed to pay the bills.
I’m now switching to just how much I need; I work way more than those hours, so it’s a BS number otherwise.

Expense: $ 4,600.

### 🗓 Future

After going through the whole ecosystem for TS + ESM, I want to go through it *again* to improve readmes, fix open issues, and modernize coding style (perhaps also through a unified eslint preset).
I’d also want to spend some time on docs on the unified website but also how to make unified more approachable as a whole.
I also remain quite enchanted about adding more of a “site generation” layer on top of unified, 
