### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2021-12-31-wooorm.md
+++ b/invoices/2021-12-31-wooorm.md
@@ -1,0 +1,18 @@
+# Invoice: unified collective
+
+*   **Date**: 2021-12-31
+*   **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+
+## Items
+
+| Item               | Description                        | Total         |
+| ------------------ | ---------------------------------- | ------------- |
+| unified collective | Development and support (December) | **$4,600.00** |
+
+***
+
+These numbers are since the previous invoice, which was on 2021-11-30.
+
+*   **Commits**: [222](https://github.com/search?q=author%3Awooorm+committer-date%3A%222021-11-30..2021-12-31%22)
+*   **Issues and PRs**: [31](https://github.com/search?q=author%3Awooorm+created%3A%222021-11-30..2021-12-31%22)
+*   **Reviews**: [78](https://github.com/search?q=reviewed-by%3Awooorm+created%3A%222021-11-30..2021-12-31%22)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Hi! Some highlights of December:

- create https://github.com/wooorm/create-gfm-fixtures, which is now used in micromark-extension-gfm*, this makes matching GFM (whether in comments or in files) much easier
- improve a bunch of docs in rehype (and `remark-lint`: https://github.com/remarkjs/remark-lint/pull/276) and add profile readmes for remark, mdx (e.g. https://github.com/mdx-js/.github/pull/28)
- verify all unified orgs on GH
- mostly carried by @remcohaszing but helped review a bunch of things around `unified-language-server` / `vscode-remark`
- took a break
- swept through most issues/PRs to close some stale ones and ping waiting ones

It doesn’t feel like a very “productive” month so it feels a bit weird sending an invoice. But then again I think open source people should also be able to take a 5 day (+ 4 weekend days) break once every many years

For January: finish rehype readmes (mostly `rehype-minify` will be a lot of work), launch MDX 2, learn a bit of rust (personally)

Happy holidays folks!

<!--do not edit: pr-->
