### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2023-03-31-wooorm.md
+++ b/invoices/2023-03-31-wooorm.md
@@ -1,0 +1,18 @@
+# Invoice: unified collective
+
+*   **Date**: 2023-03-31
+*   **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+
+## Items
+
+| Item               | Description                     | Total         |
+| ------------------ | ------------------------------- | ------------- |
+| unified collective | Development and support (March) | **$4,800.00** |
+
+***
+
+The numbers for this month:
+
+*   **Commits**: [433](https://github.com/search?q=author%3Awooorm+committer-date%3A%222023-01-31..2023-03-31%22\&type=commits)
+*   **Issues and PRs**: [29](https://github.com/search?q=author%3Awooorm+created%3A%222023-01-31..2023-03-31%22\&type=issues)
+    )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Hi! Some highlights of feb and march!

I went on a holiday for the last 2 weeks of Feb, and felt a bit bad about an invoice for a short, halved, month. So I thought I’d work on some other stuff for the first 2 weeks in March, and sort of combine the two. But I made [`markdown-tm-language`](https://github.com/wooorm/markdown-tm-language), which solved [several bugs in the collective](https://github.com/mdx-js/mdx-analyzer/pull/317). So this is more like 6 weeks of work for this invoice!

#### unified

- Gone through `vfile`, did the last ones in `syntax-tree`, and started work on `micromark`, again solving TS 4.9, improving docs, JSDocs, types, `null` handling, updating deps and actions, tests to use `node:test` and `node:assert/strict`, etc. For micromark I started porting things from `markdown-rs`.
- Investigate all the differences in JSX implementations, support them in `hast-util-to-jsx-runtime`: https://github.com/syntax-tree/hast-util-to-jsx-runtime/releases/tag/1.2.0
- Add improved support for props in non-React JSX https://github.com/syntax-tree/hast-util-to-estree/releases/tag/2.3.0, see also 2.3.1, 2.3.2.
- Improve many small things in MDX https://github.com/mdx-js/mdx/releases/tag/2.3.0
- Switched to a new XML parser in [`xast-util-from-xml`](https://github.com/syntax-tree/xast-util-from-xml/releases/tag/3.0.0). Mostly the hard work of the maintainer of `@rgrove/parse-xml`, but included some work from me to test, raise issues, suggest ideas, and port everything

#### Adjacent to unified

- Raised several issues with `github/linguist`, that will help markdown/MDX highlighting on Github: fix bugs, will help `@wooorm/starry-night`, to include the new markdown and MDX grammars, and to [fix support for ` ```md `](https://github.com/github/linguist/pull/6338), which should improve about 30k repos in the wild that use it!
- Add `<search>` to CM :) https://github.com/commonmark/commonmark-spec/commit/414c3e12d9d8803f07d8524f9e92136068b1ebe8

---

For next month, I’ll focus on micromark. Backporting things from `markdown-rs`. Not sure if I’ll either do the breaking changes immediately, or move on to unified/remark/rehype/retext first.


<!--do not edit: pr-->
