### PR TITLE
Move @remcohaszing to rehype/remark/unified releaser

### DIFF
--- a/data/teams.yml
+++ b/data/teams.yml
@@ -23,7 +23,7 @@
     JounQin: merger
     Murderlon: merger
     Rokt33r: merger
-    remcohaszing: merger
+    remcohaszing: releaser
     vhf: contributor
     wooorm: releaser
     zcei: contributor
@@ -38,7 +38,7 @@
     JounQin: merger
     kmck: merger
     Murderlon: merger
-    remcohaszing: merger
+    remcohaszing: releaser
     Rokt33r: merger
     sobolevn: contributor
     vhf: merger
@@ -53,7 +53,7 @@
     JounQin: merger
     kmck: releaser
     Murderlon: merger
-    remcohaszing: merger
+    remcohaszing: releaser
     vhf: contributor
     wooorm: releaser
 - name: retext

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,10 @@ The **unified team** is an *[organization][]* team responsible for
     \<tituswormer\@gmail.com>
     (**lead**)
 
+*   Remco Haszing
+    ([**@remcohaszing**](https://github.com/remcohaszing))
+    \<remcohaszing\@gmail.com>
+
 ##### Mergers
 
 *   Christian Murphy
@@ -151,10 +155,6 @@ The **unified team** is an *[organization][]* team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     \<merlijn\@soverin.net>
-
-*   Remco Haszing
-    ([**@remcohaszing**](https://github.com/remcohaszing))
-    \<remcohaszing\@gmail.com>
 
 #### Contributors
 
@@ -192,6 +192,10 @@ The **remark team** is an *[organization][]* team responsible for
     \<tituswormer\@gmail.com>
     (**lead**)
 
+*   Remco Haszing
+    ([**@remcohaszing**](https://github.com/remcohaszing))
+    \<remcohaszing\@gmail.com>
+
 ##### Mergers
 
 *   Christian Murphy
@@ -221,10 +225,6 @@ The **remark team** is an *[organization][]* team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     \<merlijn\@soverin.net>
-
-*   Remco Haszing
-    ([**@remcohaszing**](https://github.com/remcohaszing))
-    \<remcohaszing\@gmail.com>
 
 *   Victor Felder
     ([**@vhf**](https://github.com/vhf))
@@ -266,6 +266,10 @@ The **rehype team** is an *[organization][]* team responsible for
     \<tituswormer\@gmail.com>
     (**lead**)
 
+*   Remco Haszing
+    ([**@remcohaszing**](https://github.com/remcohaszing))
+    \<remcohaszing\@gmail.com>
+
 ##### Mergers
 
 *   Christian Murphy
@@ -283,10 +287,6 @@ The **rehype team** is an *[organization][]* team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     \<merlijn\@soverin.net>
-
-*   Remco Haszing
-    ([**@remcohaszing**](https://github.com/remcohaszing))
-    \<remcohaszing\@gmail.com>
 
 #### Contributors
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

See [Motion to nominate a maintainer](https://github.com/unifiedjs/collective/blob/main/members.md#motion-to-nominate-a-maintainer) for more information.

See [recent work in rehype](https://github.com/search?q=author%3Aremcohaszing+org%3Ahypejs&type=Issues) See [recent work in remark](https://github.com/search?q=author%3Aremcohaszing+org%3Aremarkjs&type=Issues) See [recent work in unified](https://github.com/search?q=author%3Aremcohaszing+org%3Aunifiedjs&type=Issues)

The intent is mostly to
- be able to release `unified-language-server`;
- be able to release `remark-language-server`;
- be able to create and release `rehype-language-server`;
- help out if we need to make a lot of releases again like recently.

<!--do not edit: pr-->
