### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2024-09-02-wooorm.md
+++ b/invoices/2024-09-02-wooorm.md
@@ -1,0 +1,16 @@
+# Invoice: unified collective
+
+* **Date**: 2024-09-02
+* **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+
+## Items
+
+| Item               | Description                      | Total         |
+| ------------------ | -------------------------------- | ------------- |
+| unified collective | Development and support (August) | **$4,800.00** |
+
+***
+
+The numbers for this month:
+
+* **Commits**: [145](https://github.com/search?q=author%3Awooorm+committer-date%3A%222024-07-31..2024-08-31%22\&type=commits)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Heya!

I’ve updated the unified website. RSS feed, `robots.txt`, sitemap, stuff like that.
More impactful, was updating all the guides and writing missing ones. Adding twoslash.
Merging OC and GH sponsors into one big list. Adding `thanks.dev` links, which is becoming a bigger share of the sponsors.
Another thing I’ve done is create a new bug-free and small estree scope manager; we were using `periscopic` in a few places but that was buggy and not maintained, so: [`estree-util-scope`](https://github.com/syntax-tree/estree-util-scope), and the [mdx commit](https://github.com/mdx-js/mdx/commit/d306f87042c8b203fb70dd14f5e450414a4c44eb).
Nice news recently was that `val.town` became a sponsor on OC, 100 monthly but also 900 one time.

Plans remain, like last month:
a) getting more sponsors, by advertising more
b) getting the issue/pr count down again, solving the bugs/nice-to-haves

but also remains time intensive to help folks and fix bugs that everyone’s running into!

<!--do not edit: pr-->
