### PR TITLE
Change who governs domains

### DIFF
--- a/permissions.md
+++ b/permissions.md
@@ -119,10 +119,11 @@ It is owned by [**@wooorm**][wooorm] and [**@johno**][johno].
 
 ## Domains
 
-The [`unifiedjs.com`](https://unifiedjs.com) and
-[`mdxjs.com`](https://mdxjs.com) domains are governed by the collective.
-They are respectively registered by [**@wooorm**][wooorm] and
-[**@johno**][johno].
+The [`unifiedjs.com`](https://unifiedjs.com),
+[`mdxjs.com`](https://mdxjs.com), and
+[`mdxjs.org`](https://mdxjs.org)
+domains are governed by the collective.
+They are registered by [**@wooorm**][wooorm].
 
 ## Email
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aunifiedjs&type=issues and https://github.com/orgs/unifiedjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

I’m shutting down Vercel as they are charging $40 per month for MDX hosting.
With that I am also moving the 2 MDX domains to another registrar, Transip, which I use personally. Which is about the same price of $10 per domain per year.
`mdxjs.org` is not in use, but is owned by us. For now I’d thought of just setting up a redirect.
This fulfills a wish from John from a year or 2 ago of moving off Vercel when they stared requesting more. But there’s no contact with John. I’ll send him an email!

<!--do not edit: pr-->
